### PR TITLE
Automatic update of Logitech.LGH from latest to 2022.7.502

### DIFF
--- a/manifests/l/Logitech/LGH/2022.7.502/Logitech.LGH.yaml
+++ b/manifests/l/Logitech/LGH/2022.7.502/Logitech.LGH.yaml
@@ -1,3 +1,6 @@
+# Automatically updated by the winget bot at 2022/Aug/22
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
+
 PackageIdentifier: Logitech.LGH
 Publisher: Logitech
 PackageName: Logitech Gaming Hub
@@ -13,7 +16,7 @@ PackageUrl: https://gaming.logicool.co.jp/en-US/innovation/g-hub.html
 License: Copyright (c) Logitech, Inc. 2020
 LicenseUrl: https://secure.logitech.com/en-us/footer/terms-of-use
 MinimumOSVersion: 10.0.0.0
-PackageVersion: latest
+PackageVersion: 2022.7.502
 InstallerType: exe
 Installers:
 - InstallerSwitches:
@@ -21,7 +24,7 @@ Installers:
     SilentWithProgress: ''
   Architecture: x64
   InstallerUrl: https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.exe
-  InstallerSha256: f188ec2eb1bd04e54c36e976e15fea1812b3a40af52a500b4782b7f0c3994364
+  InstallerSha256: 4E028BF5519B10CA14B557530B39C9B53981960E52BFBDF75C483158AFCC1E4B
 PackageLocale: en-US
 ManifestType: singleton
 ManifestVersion: 1.0.0

--- a/manifests/l/Logitech/LGH/2022.7.502/Logitech.LGH.yaml
+++ b/manifests/l/Logitech/LGH/2022.7.502/Logitech.LGH.yaml
@@ -1,0 +1,27 @@
+PackageIdentifier: Logitech.LGH
+Publisher: Logitech
+PackageName: Logitech Gaming Hub
+Author: Logitech
+ShortDescription: Customize Logitech G gaming mice, keyboards, headsets, speakers, and other devices
+Moniker: lghub
+Tags:
+- mouse
+- keyboard
+- headset
+- driver
+PackageUrl: https://gaming.logicool.co.jp/en-US/innovation/g-hub.html
+License: Copyright (c) Logitech, Inc. 2020
+LicenseUrl: https://secure.logitech.com/en-us/footer/terms-of-use
+MinimumOSVersion: 10.0.0.0
+PackageVersion: latest
+InstallerType: exe
+Installers:
+- InstallerSwitches:
+    Silent: ''
+    SilentWithProgress: ''
+  Architecture: x64
+  InstallerUrl: https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.exe
+  InstallerSha256: f188ec2eb1bd04e54c36e976e15fea1812b3a40af52a500b4782b7f0c3994364
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0


### PR DESCRIPTION
Automation detected that manifest Logitech.LGH needs to be updated
Reason:
- Installer(s) found with hash mismatch.
