### PR TITLE
Automatic update of Stride.Stride from 4.0.1.0 to 5.0.6

### DIFF
--- a/manifests/s/Stride/Stride/5.0.6/Stride.Stride.yaml
+++ b/manifests/s/Stride/Stride/5.0.6/Stride.Stride.yaml
@@ -1,7 +1,10 @@
+# Automatically updated by the winget bot at 2022/Aug/22
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
+
 PackageIdentifier: Stride.Stride
 Publisher: Stride
 PackageName: Stride
-PackageVersion: 4.0.1.0
+PackageVersion: 5.0.6
 License: MIT
 InstallerType: exe
 LicenseUrl: https://github.com/stride3d/stride/raw/master/LICENSE.md
@@ -26,7 +29,7 @@ Installers:
 - Architecture: x64
   InstallerType: exe
   InstallerUrl: https://stride3d.net/files/StrideSetup.exe
-  InstallerSha256: 182FDDCEC8EDAB176F4380EC3952319ED0BBFDCDAB577A01F5D222876DB50CE9
+  InstallerSha256: CEF0C590BBF88C948495F8B3D0681732056A2B44F3C0169F488B265FED9AE29F
   InstallerSwitches:
     Silent: /quiet
     SilentWithProgress: /passive

--- a/manifests/s/Stride/Stride/5.0.6/Stride.Stride.yaml
+++ b/manifests/s/Stride/Stride/5.0.6/Stride.Stride.yaml
@@ -1,0 +1,35 @@
+PackageIdentifier: Stride.Stride
+Publisher: Stride
+PackageName: Stride
+PackageVersion: 4.0.1.0
+License: MIT
+InstallerType: exe
+LicenseUrl: https://github.com/stride3d/stride/raw/master/LICENSE.md
+Moniker: Stride3d
+Tags:
+- stride
+- stride3d
+- xenko
+- game engine
+- game development
+- gamedev
+- 3d
+- 2d
+- .NET
+- dotnet
+- net
+- C#
+- csharp
+ShortDescription: Stride is an open-source MIT C# game engine designed for the future of gaming.
+PackageUrl: https://stride3d.net/
+Installers:
+- Architecture: x64
+  InstallerType: exe
+  InstallerUrl: https://stride3d.net/files/StrideSetup.exe
+  InstallerSha256: 182FDDCEC8EDAB176F4380EC3952319ED0BBFDCDAB577A01F5D222876DB50CE9
+  InstallerSwitches:
+    Silent: /quiet
+    SilentWithProgress: /passive
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0


### PR DESCRIPTION
Automation detected that manifest Stride.Stride needs to be updated
Reason:
- Installer(s) found with hash mismatch.
